### PR TITLE
Fix "Only variables should be passed by reference" error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /vendor
 /node_modules
 Homestead.yaml

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -37,8 +37,13 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function map(Router $router)
     {
-        $directories = array_splice(scandir(app_path('API')), 0, 2);
+        $directories = new \DirectoryIterator(app_path('API'));
+
         foreach ($directories as $directory) {
+            if (! $directory->isDir() || $directory->isDot()) {
+                continue;
+            }
+
             $router->group(['namespace' => $this->namespace.'\\'.$directory.'\\Http', 'prefix' => $directory.'/api'], function ($router) use ($directory) {
                 require app_path('API/'.$directory.'/routes.php');
             });


### PR DESCRIPTION
I think this is a strict mode only thing. When trying to run artisan commands I got the above error (due to the `scandir` output being passed into `array_splice`), this solves it.
